### PR TITLE
Update to fix latest Tablo json 

### DIFF
--- a/Contents/Code/__init__.py
+++ b/Contents/Code/__init__.py
@@ -126,7 +126,7 @@ def MainMenu():
                                key=Callback(scheduled, title="Scheduled Recordings"),
                                title="Scheduled Recordings"))
         oc.add(DirectoryObject(thumb=R('icon_settings_hd.jpg'), key=Callback(Help, title="Help"), title="Help"))
-		oc.add(PrefsObject(title='Change your IP Address', thumb=R(ICON_PREFS)))
+        oc.add(PrefsObject(title='Change your IP Address', thumb=R(ICON_PREFS)))
     return oc
 
 


### PR DESCRIPTION
The current Tablo.bundle is failing when in this environment:
Plex: Version 0.9.12.19 running on i86 NAS
Tablo: Version 2.2.8 - 4 tuner
Tested against windows + firefox, ubuntu + firefox, apple tv 4 w/ plex client and iPhone 6S with plex client.
The old was failing on all the recorded shows because it was looking for a missing jsonFromTribune element. I've updated the JSON processing to get the required data from Tablo in the jsonForClient object.