### PR TITLE
Add month/day to title

### DIFF
--- a/Contents/Code/__init__.py
+++ b/Contents/Code/__init__.py
@@ -54,11 +54,11 @@ def Start():
     # Object / Directory / VideoClip setup
     ObjectContainer.title1 = TITLE
     ObjectContainer.view_group = 'InfoList'
-    #ObjectContainer.art = R(ART)
+    ObjectContainer.art = R(ART)
     DirectoryObject.thumb = R(NOTV_ICON)
-    #DirectoryObject.art = R(ART)
+    DirectoryObject.art = R(ART)
     VideoClipObject.thumb = R(NOTV_ICON)
-    #VideoClipObject.art = R(ART)
+    VideoClipObject.art = R(ART)
 
     # HTTP setup
     HTTP.CacheTime = CACHE_1HOUR

--- a/Contents/Code/__init__.py
+++ b/Contents/Code/__init__.py
@@ -290,6 +290,7 @@ def scheduled(title):
         if 'images' in airingData:
             imagedid = airingData['images'][0]['imageID']
         plexlog('airingdata loop', airingData)
+        plexlog('unixtimestarted', str(Datetime.FromTimestamp(unixtimestarted)))
         # All commented out are set in TabloLive.pys helpers
         oc.add(
                 # TVShowObject(
@@ -305,7 +306,7 @@ def scheduled(title):
                         thumb=Resource.ContentsOfURLWithFallback(
                             url='http://' + ipaddress + ':18080/stream/thumb?id=' + str(imagedid), fallback=NOTV_ICON),
                         # art= Resource.ContentsOfURLWithFallback(url=airingData['art'], fallback=ART),
-                        tagline=unixtimestarted
+                        tagline=str(Datetime.FromTimestamp(unixtimestarted))
                         # duration = airingData['duration']  #description = airingData['description']
                 )
         )
@@ -1016,7 +1017,8 @@ def episodes(title, seriesid, seasonnum):
 
             except Exception as e:
                 Log(" Failed on episode " + str(e))
-    oc.objects.sort(key=lambda obj: obj.index)
+    # sort by reverse air date, newest first
+    oc.objects.sort(key=lambda obj: obj.originally_available_at, reverse=True)
 
     return oc
 

--- a/Contents/Code/__init__.py
+++ b/Contents/Code/__init__.py
@@ -1042,7 +1042,7 @@ def getepisode(episodeDict):
     return EpisodeObject(
             art=episodeDict['backgroundart'],
             url=Encodeobj('TabloRecording', episodeDict),
-            title=getExtendedTitle(episodeDict['title'], episodeDict['airdate'], 0, 0),
+            title=episodeDict['title'],
             season=episodeDict['seasonnum'],
             index=episodeDict['episodenum'],
             summary=episodeDict['summary'],

--- a/Contents/Code/__init__.py
+++ b/Contents/Code/__init__.py
@@ -54,11 +54,11 @@ def Start():
     # Object / Directory / VideoClip setup
     ObjectContainer.title1 = TITLE
     ObjectContainer.view_group = 'InfoList'
-    ObjectContainer.art = R(ART)
+    #ObjectContainer.art = R(ART)
     DirectoryObject.thumb = R(NOTV_ICON)
-    DirectoryObject.art = R(ART)
+    #DirectoryObject.art = R(ART)
     VideoClipObject.thumb = R(NOTV_ICON)
-    VideoClipObject.art = R(ART)
+    #VideoClipObject.art = R(ART)
 
     # HTTP setup
     HTTP.CacheTime = CACHE_1HOUR
@@ -1042,7 +1042,7 @@ def getepisode(episodeDict):
     return EpisodeObject(
             art=episodeDict['backgroundart'],
             url=Encodeobj('TabloRecording', episodeDict),
-            title=episodeDict['title'],
+            title=getExtendedTitle(episodeDict['title'], episodeDict['airdate'], 0, 0),
             season=episodeDict['seasonnum'],
             index=episodeDict['episodenum'],
             summary=episodeDict['summary'],

--- a/Contents/Code/__init__.py
+++ b/Contents/Code/__init__.py
@@ -20,15 +20,15 @@ TabloAPI = tablohelpers.TabloAPI
 # plexlog = SharedCodeService.TabloHelpers.plexlog
 
 '''#### Define Global Vars ####'''
-TITLE = 'Tablo'
+TITLE = 'TabloX'
 ART = 'TabloProduct_FrontRight-default.jpg'
 ICON = 'tablo_icon_focus_hd.png'
 NOTV_ICON = 'no_tv_110x150.jpg'
 ICON_PREFS = 'icon_settings_hd.jpg'
 SHOW_THUMB = 'no_tv_110x150.jpg'
 PREFIX = '/video/Tablo'
-LOG_PREFIX = "***TabloTV: "
-VERSION = "0.992"
+LOG_PREFIX = "***TabloTV RBW: "
+VERSION = "0.992a"
 FOLDERS_COUNT_IN_TITLE = True  # Global VAR used to enable counts on titles
 debugit = True
 
@@ -1347,6 +1347,30 @@ def loadData():
 
 
 '''#########################################
+    Name: getExtendedTitle()
+
+    Parameters: name: String, airdate: String, en: Integer, sn: Integer
+
+    Purpose: Add month/day and season/episode number to generic title
+
+    Returns: String
+
+    Notes:
+#########################################'''
+
+def getExtendedTitle(name, airdate, en=0, sn=0):
+    dt = Datetime.ParseDate(airdate)
+    mmdd = dt.strftime("%m/%d")
+    if sn != 0 and en != 0:
+        se = ' s{0}e{1}'.format(sn,en)
+    else:
+        se = ''
+    title = '{0} ({1}{2})'.format(name,mmdd,se)
+    Log(LOG_PREFIX + 'ext title = ' + title)
+    return title
+
+
+'''#########################################
     Name: getEpisodeDict()
 
     Parameters: None
@@ -1409,6 +1433,13 @@ def getEpisodeDict(ipaddress, episodeID, UseMeta):
             if 'title' in seriesinfo:
                 recordingDict['showname'] = seriesinfo['title']
                 recordingDict['title'] = seriesinfo['title']
+                # if we have the air date, then add it to the generic title
+                # since it helps distinguish shows with no distinct episode title
+                # like 'NBC Nightly News' and no default date ordering of episodes
+                if 'jsonForClient' in recordinginfo[root]:
+                    episodeinfo = recordinginfo[root]['jsonForClient']
+                    if 'airDate' in episodeinfo:
+                        recordingDict['title'] = getExtendedTitle(seriesinfo['title'], episodeinfo['airDate'])
             else:
                 recordingDict['showname'] = ''
             recordingDict['seriesdesc'] = ''

--- a/Contents/Code/__init__.py
+++ b/Contents/Code/__init__.py
@@ -20,15 +20,15 @@ TabloAPI = tablohelpers.TabloAPI
 # plexlog = SharedCodeService.TabloHelpers.plexlog
 
 '''#### Define Global Vars ####'''
-TITLE = 'TabloX'
+TITLE = 'Tablo'
 ART = 'TabloProduct_FrontRight-default.jpg'
 ICON = 'tablo_icon_focus_hd.png'
 NOTV_ICON = 'no_tv_110x150.jpg'
 ICON_PREFS = 'icon_settings_hd.jpg'
 SHOW_THUMB = 'no_tv_110x150.jpg'
 PREFIX = '/video/Tablo'
-LOG_PREFIX = "***TabloTV RBW: "
-VERSION = "0.992a"
+LOG_PREFIX = "***TabloTV: "
+VERSION = "0.992"
 FOLDERS_COUNT_IN_TITLE = True  # Global VAR used to enable counts on titles
 debugit = True
 


### PR DESCRIPTION
## Changes
- create an extended title with mm/dd air date info for shows with no distinct episode titles
- helps distinguish episodes when no default air date ordering occurs
- reverse air date order for shows
- fix tagline critical error
- fix ATV4 Plex app v1.1 issues
## Screenshot

(before date order change)
![screen shot 2016-04-28 at 12 09 53 am](https://cloud.githubusercontent.com/assets/1273492/14875248/c491c636-0cd6-11e6-8118-a570dcd77423.png)
